### PR TITLE
Explicitly fire query when incrementing project counter on MySQL

### DIFF
--- a/src/sentry/models/counter.py
+++ b/src/sentry/models/counter.py
@@ -80,7 +80,9 @@ def increment_project_counter(project, delta=1):
                      update value = @new_val := value + %s;
                      select @new_val;
             ''', [project.id, delta, delta])
-            return cur.fetchone()[0]
+            res = cur.fetchone()
+            db.commit()
+            return res[0]
         else:
             raise AssertionError("Not implemented database engine path")
     finally:


### PR DESCRIPTION
Changes proposed in this pull request:
When accessing cur.fetchone() instantly after executing the query the result will be None.
Accessing [0] of None throws `TypeError: 'NoneType' object has no attribute '__getitem__'`
By explicitly firing the query we make sure that that we get a response.

This was a problem i encountered when running sentry workers, it would keep throwing this 
error and producing high load on the worker node. While MySQL is not officially supported
it might still be some people that will benefit from this fix.

Note: When testing this code I was using MariaDB 5.5.45

@getsentry/team
